### PR TITLE
Limit the new files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tech.mlsql</groupId>
     <artifactId>delta-plus_2.11</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <name>Delta Plus</name>
     <url>https://github.com/allwefantasy/delta-plus.git</url>
     <description>

--- a/src/main/java/org/apache/spark/sql/delta/sources/MLSQLDeltaDataSource.scala
+++ b/src/main/java/org/apache/spark/sql/delta/sources/MLSQLDeltaDataSource.scala
@@ -41,7 +41,7 @@ class MLSQLDeltaDataSource extends DeltaDataSource {
 
     val deltaLog = DeltaLog.forTable(sqlContext.sparkSession, path)
 
-    if (parameters.contains(UpsertTableInDelta.ID_COLS)) {
+    if (parameters.contains(UpsertTableInDelta.ID_COLS) && deltaLog.snapshot.version > -1) {
       UpsertTableInDelta(data, Option(mode), None, deltaLog,
         new DeltaOptions(Map[String, String](), sqlContext.sparkSession.sessionState.conf),
         Seq(),


### PR DESCRIPTION
If you have set fileNum, then every upsert operation will make sure the new files are fileNum+1.
If not, then very upsert operation will make sure the new file number is not bigger then before+1

you can set fileNum in configuration.