### PR TITLE
解决主键在scheme中非第一列时union改变原scheme导致delta类型检查不一致报错问题

### DIFF
--- a/src/main/java/org/apache/spark/sql/delta/commands/UpsertTableInDelta.scala
+++ b/src/main/java/org/apache/spark/sql/delta/commands/UpsertTableInDelta.scala
@@ -308,7 +308,7 @@ case class UpsertTableInDelta(_data: Dataset[_],
           txn.writeFiles(notChangedRecords, Some(options))
         } else Seq[AddFile]()
       } else {
-        var newTempData = data.toDF().union(notChangedRecords)
+        var newTempData = data.toDF().unionByName(notChangedRecords)
         val finalNumIfKeepFileNum = if (deletedFiles.size == 0) 1 else deletedFiles.size
         newTempData = if (upsertConf.keepFileNum()) newTempData.repartitionByRange(finalNumIfKeepFileNum, upsertConf.toIdCols: _*) else newTempData
         txn.writeFiles(newTempData, Some(options))


### PR DESCRIPTION
由于delta有验证数据顺序及其类型 https://docs.delta.io/latest/delta-batch.html#schema-validation
:DataFrame column data types must match the column data types in the target table. If they don’t match, an exception is raised.

当mysql原表结构为col1,col2,id，而不是常规的id,col1,col2时
notChangedRecords 对应schema为 id,col1,col2
data 对应schema为 col1,col2,id
var newTempData = data.toDF().union(notChangedRecords) 返回 schema为 id,col1,col2

最终由
org.apache.spark.sql.catalyst.analysis.CheckAnalysis#failAnalysis
检查报错

修改为unionByName返回 newTempData 对应schema为col1,col2,id 可更新成功